### PR TITLE
Fix string representation of Input.VirtualFile in exception

### DIFF
--- a/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
+++ b/scalafix-testkit/src/main/scala/scalafix/testkit/SemanticRuleSuite.scala
@@ -135,7 +135,7 @@ object SemanticRuleSuite {
         x.is[Token.Comment] && x.syntax.startsWith("/*")
       }
       .getOrElse {
-        val input = tokens.headOption.fold("the file")(_.input.toString)
+        val input = tokens.headOption.fold("the file")(_.input.path)
         throw new IllegalArgumentException(
           s"Missing /* */ comment at the top of $input"
         )


### PR DESCRIPTION
Fix the string representation of Input.VirtualFile source in message "Missing comment"